### PR TITLE
add one-click deploy docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,6 +43,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.11-alpine
 WORKDIR /app
 
 # Install dependencies
-COPY python/examples/requirements.txt .
-RUN uv venv && uv pip install --no-cache-dir -r requirements.txt
+RUN uv venv && uv tool --no-cache install httmcp
 
 # Install the application
 RUN apk add --no-cache --virtual .run-deps bash openssl nginx nginx-mod-http-nchan

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM ghcr.io/astral-sh/uv:python3.11-alpine
+
+WORKDIR /app
+
+# Install dependencies
+COPY python/examples/requirements.txt .
+RUN uv venv && uv pip install --no-cache-dir -r requirements.txt
+
+# Install the application
+RUN apk add --no-cache --virtual .run-deps bash openssl nginx nginx-mod-http-nchan
+
+# Configure Nginx
+# prepend include modules/*.conf; to nginx.conf
+RUN mkdir -p '/etc/nginx/toplevel.conf.d' \
+   && mkdir -p '/etc/nginx/dhparam' \
+   && mkdir -p '/etc/nginx/certs' \
+   && mkdir -p '/usr/share/nginx/html/errors' \
+   && mkdir -p '/etc/nginx/conf.d'
+
+# copy the nginx configuration
+COPY docker/default.conf /etc/nginx/http.d/default.conf
+COPY docker/entrypoint.sh /
+
+# Expose the port the app runs on
+EXPOSE 80
+EXPOSE 8000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,0 +1,67 @@
+
+# MCP server configuration
+server {
+    # error_log /dev/stderr debug;
+    listen 80 default_server;
+    subrequest_output_buffer_size 1M;
+
+    location ~ ^/mcp/([a-zA-Z0-9-_]+)$ {
+        set $mcp_server_name $1;
+        proxy_pass http://127.0.0.1:8000/mcp/$mcp_server_name/;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        set $mcp_server_transport "websocket";
+        if ($http_connection != "Upgrade") {
+            set $mcp_server_transport "sse";
+        }
+        proxy_set_header X-MCP-Transport $mcp_server_transport;
+    }
+
+    location ~ ^/internal/([a-zA-Z0-9-_]+)/([a-zA-Z0-9-_]+)$ {
+        internal;
+        nchan_channel_id $2;
+        # only support websocket and eventsource
+        nchan_subscriber websocket eventsource;
+        nchan_subscribe_request /internal/mcp-process;
+        # eventsource can not send message
+        nchan_publisher websocket;
+        nchan_publisher_upstream_request /internal/mcp-process;
+    }
+
+    # MCP channel location, the path is the MCP server name
+    location ~ ^/mcp/(.+)/(.+)$ {
+        # Extract MCP server name
+        set $mcp_server_name $1;
+        nchan_channel_id $2;
+        # Message storage
+        nchan_store_messages off;
+        nchan_publisher http;
+        # only using when the transport is eventsource, send message by using http request
+        set $mcp_server_transport "sse";
+        # skip send message to upstream when have X-EventSource-Event header
+        if ($http_x_eventsource_event = "") {
+            nchan_publisher_upstream_request /internal/mcp-process;
+        }
+    }
+    
+    # Internal endpoint for processing MCP requests
+    location /internal/mcp-process {
+        internal;  # Only accessible within nginx
+
+        set $method 'endpoint';
+        # Extract method from JSON request body
+        if ($request_body ~* '"method"\s*:\s*"([^"]+)"') {
+            set $method $1;
+        }
+        proxy_http_version 1.0;  # using HTTP/1.0 for subrequests
+        # Proxy to the Python Starlette backend
+        proxy_pass http://127.0.0.1:8000/mcp/$mcp_server_name/$method;
+        proxy_set_header Host $mcp_server_name.mcp.io;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header X-MCP-Server-Name $mcp_server_name;
+        proxy_set_header X-MCP-Transport $mcp_server_transport;
+        proxy_set_header X-MCP-Session-ID $nchan_channel_id;
+        proxy_set_header Content-Type $content_type;
+        proxy_pass_request_body on;
+    }
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+nginx && uvx httmcp --host 0.0.0.0 --port 8000 -p http://127.0.0.1:80 -f $@

--- a/python/examples/requirements.txt
+++ b/python/examples/requirements.txt
@@ -2,5 +2,5 @@ fastapi==0.115.11
 uvicorn==0.23.1
 httpx==0.27.0
 mcp==1.3.0
-httmcp==0.2.0
+httmcp==0.3.1
 nest-asyncio


### PR DESCRIPTION
1. build image and start server with openapi.json
```
sudo docker build -t httmcp -f docker/Dockerfile .

sudo docker run --rm -it -p 8000:80 httmcp https://raw.githubusercontent.com/lloydzhou/openapiclient/refs/heads/main/examples/jinareader.json
```
2. or using docker image from docker hub
```
docker pull lloydzhou/httmcp
sudo docker run --rm -it -p 8000:80 lloydzhou/httmcp https://raw.githubusercontent.com/lloydzhou/openapiclient/refs/heads/main/examples/jinareader.json
```

3. debug with mcp inspector
![image](https://github.com/user-attachments/assets/33feff00-70a6-4243-8d98-2516f519eb90)
